### PR TITLE
Update SwiftPM to Swift 4 Manifest Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ import PackageDescription
 let package = Package(
     name: "EmbassyExample",
     dependencies: [
-        .Package(url: "https://github.com/envoy/Embassy.git",
-                 majorVersion: 4),
+        .package(url: "https://github.com/envoy/Embassy.git",
+                 from: "4.0.0"),
     ]
 )
 ```


### PR DESCRIPTION
Based on official documentation, migrate the package installation to the new format. 

Link: https://swift.org/blog/swift-package-manager-manifest-api-redesign/