### PR TITLE
Swift 4.1 compiler warning fix

### DIFF
--- a/Sources/TCPSocket.swift
+++ b/Sources/TCPSocket.swift
@@ -228,7 +228,7 @@ public final class TCPSocket {
             guard result >= 0 else {
                 throw OSError.lastIOError()
             }
-            switch Int32(address.ss_family) {
+            switch Int32(pointer.pointee.ss_family) {
             case AF_INET:
                 return try pointer.withMemoryRebound(
                     to: sockaddr_in.self,


### PR DESCRIPTION
On swift 4.1 there's a compiler warning:

```
Overlapping accesses to 'address', but modification requires exclusive access; consider copying to a local variable
```

This fixes the compiler warning.