### PR TITLE
Fix warning in Swift 4.1.50

### DIFF
--- a/Sources/HTTPConnection.swift
+++ b/Sources/HTTPConnection.swift
@@ -116,7 +116,7 @@ public final class HTTPConnection {
             }
         }
         logger.info(
-            "Header parsed, method=\(method), path=\(path.debugDescription), " +
+            "Header parsed, method=\(method!), path=\(path.debugDescription), " +
             "version=\(version.debugDescription), headers=\(headers)"
         )
         request = HTTPRequest(


### PR DESCRIPTION
Since implicitly unwrapped optionals got a bit of a makeover, this IUO
caused a warning with Swift 4.1.50 (Xcode 10). This change is backwards
compatible with Swift 4.1.2 (Xcode 9.4)