### PR TITLE
Remove unnecessary UnsafePointer init

### DIFF
--- a/Sources/Errors.swift
+++ b/Sources/Errors.swift
@@ -19,5 +19,5 @@ public enum OSError: Error {
 
 /// Return description for last error
 func lastErrorDescription() -> String {
-    return String(cString: UnsafePointer(strerror(errno)))
+    return String(cString: strerror(errno))
 }


### PR DESCRIPTION
strerror already returns an UnsafePointer so we don't need this. This
causes a compiler error in the Xcode beta for unrelated reasons.