### PR TITLE
Update Hashable implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode10.1
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
     - LANG=en_US.UTF-8
     - WORKSPACE=Embassy.xcworkspace
     - IOS_FRAMEWORK_SCHEME="Embassy-iOS"
-    - IOS_SDK=iphonesimulator11.2
+    - IOS_SDK=iphonesimulator12.1
     - MACOS_FRAMEWORK_SCHEME="Embassy-macOS"
-    - MACOS_SDK=macosx10.13
+    - MACOS_SDK=macosx10.14
   matrix:
-    - DESTINATION="OS=11.2,name=iPhone 6S"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"
+    - DESTINATION="OS=12.1,name=iPhone 6S"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"
     - DESTINATION="arch=x86_64"                SCHEME="$MACOS_FRAMEWORK_SCHEME"   SDK="$MACOS_SDK"
 
 script:

--- a/Sources/HTTPConnection.swift
+++ b/Sources/HTTPConnection.swift
@@ -263,6 +263,6 @@ public func == (lhs: HTTPConnection, rhs: HTTPConnection) -> Bool {
 
 extension HTTPConnection: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(uuid.hashValue)
+        hasher.combine(uuid)
     }
 }

--- a/Sources/HTTPConnection.swift
+++ b/Sources/HTTPConnection.swift
@@ -262,7 +262,7 @@ public func == (lhs: HTTPConnection, rhs: HTTPConnection) -> Bool {
 }
 
 extension HTTPConnection: Hashable {
-    public var hashValue: Int {
-        return uuid.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid.hashValue)
     }
 }

--- a/Tests/EmbassyTests/TestingHelpers.swift
+++ b/Tests/EmbassyTests/TestingHelpers.swift
@@ -137,7 +137,8 @@ func == (lhs: FileDescriptorEvent, rhs: FileDescriptorEvent) -> Bool {
 }
 
 extension FileDescriptorEvent: Hashable {
-    var hashValue: Int {
-        return fileDescriptor.hashValue + ioEvent.hashValue
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(fileDescriptor)
+        hasher.combine(ioEvent)
     }
 }


### PR DESCRIPTION
This updates to the new API to avoid the Swift 5 compiler deprecation
warnings.