### PR TITLE
Add `swift-tools-version`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
I'm receiving the following error on checkout on a Swift 5 system:

```bash
.build/checkouts/Embassy' is using Swift tools version 3.1.0 which is no longer supported; use 4.0.0 or newer instead
```

Adding the above line resolves this 👌