### PR TITLE
Set a target in Package.swift so other projects can import Embassy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.2
+
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "Embassy"
+    name: "Embassy",
+    targets: [.target(name: "Embassy", path: "./Sources")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,5 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "Embassy",
+    products: [.library(name: "Embassy", targets: ["Embassy"])],
     targets: [.target(name: "Embassy", path: "./Sources")]
 )


### PR DESCRIPTION
Apparently the way you set up the Package.swift file has changed quite a bit, and you now have to explicitly define a target and source files that you want to make available to other projects that use the Swift Package Manager.

I've been trying to get SourceKittenDaemon updated to work with Swift 5/Xcode 10.2, and this seems to make SPM happy.