### PR TITLE
Mention how to bind to all addresses in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Then you can visit `http://[::1]:8080/foo-bar` in the browser and see
 the path you're visiting is "/foo-bar"
 ```
 
+By default, the server will be bound only to the localhost interface (::1) for security reasons. If you want to access your server over an external network, you'll need to change the bind interface to all addresses:
+
+```Swift
+let server = DefaultHTTPServer(eventLoop: loop, interface: "::", port: 8080)
+```
+
 ## Async Event Loop
 
 To use the async event loop, you can get it via key `embassy.event_loop` in `environ` dictionary and cast it to `EventLoop`. For example, you can create an SWSGI app which delays `sendBody` call like this


### PR DESCRIPTION
It took me a little while to notice that the default bind address is localhost. Since most people (including myself) are not fluent in IPv6 addresses, it's not very obvious that "::1" indicates localhost and will prevent non-local connections. I added a line to the README to explain it so other people may be less confused than I was.