### PR TITLE
Added original request headers to the environ.

### DIFF
--- a/Sources/HTTPConnection.swift
+++ b/Sources/HTTPConnection.swift
@@ -129,6 +129,7 @@ public final class HTTPConnection {
         environ["SERVER_NAME"] = serverName
         environ["SERVER_PORT"] = String(serverPort)
         environ["SERVER_PROTOCOL"] = "HTTP/1.1"
+        environ["REQUEST_HEADERS"] = headers
 
         // set SWSGI keys
         environ["swsgi.version"] = "0.1"


### PR DESCRIPTION
The information regarding the request headers are currently lost and not accessible using the `environ`. This change will allow to check the original request headers in a later time by accessing to the `environ` dictionary.