### PR TITLE
[Bugfix] Fix SIGABRT in KqueueSelector

### DIFF
--- a/Sources/KqueueSelector.swift
+++ b/Sources/KqueueSelector.swift
@@ -66,13 +66,8 @@ public final class KqueueSelector: Selector {
         }
 
         // register events to kqueue
-
-        // Notice: we need to get the event count before we go into
-        // `withUnsafeMutableBufferPointer`, as we cannot rely on it inside the closure
-        // (you can read the offical document)
-        let keventCount = kevents.count
         guard kevents.withUnsafeMutableBufferPointer({ pointer in
-            kevent(kqueue, pointer.baseAddress, Int32(keventCount), nil, Int32(0), nil) >= 0
+            kevent(kqueue, pointer.baseAddress, Int32(pointer.count), nil, Int32(0), nil) >= 0
         }) else {
             throw OSError.lastIOError()
         }
@@ -107,13 +102,8 @@ public final class KqueueSelector: Selector {
         }
 
         // unregister events from kqueue
-
-        // Notice: we need to get the event count before we go into
-        // `withUnsafeMutableBufferPointer`, as we cannot rely on it inside the closure
-        // (you can read the offical document)
-        let keventCount = kevents.count
         guard kevents.withUnsafeMutableBufferPointer({ pointer in
-            kevent(kqueue, pointer.baseAddress, Int32(keventCount), nil, Int32(0), nil) >= 0
+            kevent(kqueue, pointer.baseAddress, Int32(pointer.count), nil, Int32(0), nil) >= 0
         }) else {
             throw OSError.lastIOError()
         }

--- a/Sources/KqueueSelector.swift
+++ b/Sources/KqueueSelector.swift
@@ -157,7 +157,9 @@ public final class KqueueSelector: Selector {
             }
             fileDescriptorIOEvents[fileDescriptor] = ioEvents
         }
-        return Array(fileDescriptorIOEvents.map { (fileDescriptorMap[$0.0]!, $0.1) })
+        return Array(fileDescriptorIOEvents.compactMap { event in
+            fileDescriptorMap[event.0].map { ($0, event.1) } ?? nil
+        })
     }
 
     public subscript(fileDescriptor: Int32) -> SelectorKey? {


### PR DESCRIPTION
Fixes issue #78 , which persisted even with #83 fix.
Our team tried this fix over the #83 , so you may want to merge both of them.
We had a SIGABRT and an EXC_BAD_ACCESS before we made this fix. And after restarting simulater and this fix, the tests run smoothly (we use Embassy for UI tests).

### Explanation

The array count was incorrectly used.
The documentation says:
> - Warning: Do not rely on anything about the array that is the target of this method during execution of the `body` closure; it might not appear to have its correct value.

Meaning we should not used kevents array in the closure. But then it continues:

> Instead, use only the `UnsafeMutableBufferPointer` argument to `body`.

So we should use the pointer provided to body, not the count calculated before the function is called.