### PR TITLE
[Bugfix] Crashes when reading the body in Release configurations

### DIFF
--- a/Sources/Atomic.swift
+++ b/Sources/Atomic.swift
@@ -69,8 +69,9 @@ final class Atomic<Value> {
     @discardableResult
     func modify(action: (Value) throws -> Value) rethrows -> Value {
         return try withValue { value in
+            let oldValue = value
             _value = try action(value)
-            return value
+            return oldValue
         }
     }
 


### PR DESCRIPTION
Fixes #96 

# Explanation

When the ``_value`` is set to a new value, the closure's parameter ``value`` is freed from memory. When this freed value was returned to the SelectorEventLoop, the app crashed. 

To avoid this, I suggest to keep a strong reference to the value object, that way it won't be deleted.