### PR TITLE
Port to Android

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,5 +4,6 @@ import PackageDescription
 let package = Package(
     name: "Embassy",
     products: [.library(name: "Embassy", targets: ["Embassy"])],
-    targets: [.target(name: "Embassy", path: "./Sources")]
+    targets: [.target(name: "Embassy", path: "./Sources"),
+              .testTarget(name: "EmbassyTests", dependencies: ["Embassy"])]
 )

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Super lightweight async HTTP server in pure Swift.
 ## Features
 
  - Swift 4 & 5
- - iOS / tvOS / MacOS / Linux
+ - iOS / tvOS / MacOS / Linux / Android
  - Super lightweight, only 1.5 K of lines
  - Zero third-party dependency
  - Async event loop based HTTP server, makes long-polling, delay and bandwidth throttling all possible

--- a/Sources/KqueueSelector.swift
+++ b/Sources/KqueueSelector.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 
 public final class KqueueSelector: Selector {
     enum Error: Swift.Error {

--- a/Sources/SelectSelector.swift
+++ b/Sources/SelectSelector.swift
@@ -66,7 +66,7 @@ public final class SelectSelector: Selector {
         let microsecondsPerSecond = 1000000
         if let timeout = timeout {
             var timeoutVal = timeval()
-            #if os(Linux)
+            #if os(Linux) || os(Android)
             timeoutVal.tv_sec = Int(timeout)
             timeoutVal.tv_usec = Int(
                 Int(timeout * Double(microsecondsPerSecond)) -

--- a/Sources/SystemLibrary.swift
+++ b/Sources/SystemLibrary.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 #else
 import Darwin
@@ -16,7 +16,7 @@ import Darwin
 
 /// Collection of system library methods and constants
 struct SystemLibrary {
-    #if os(Linux)
+    #if os(Linux) || os(Android)
         // MARK: Linux constants
         static let fdSetSize = FD_SETSIZE
         static let nfdbits: Int32 = Int32(MemoryLayout<Int>.size) * 8
@@ -42,49 +42,66 @@ struct SystemLibrary {
         static func fdSet(fd: Int32, set: inout fd_set) {
             let intOffset = Int(fd / SystemLibrary.nfdbits)
             let bitOffset = Int(fd % SystemLibrary.nfdbits)
+          #if os(Android)
+            var fd_bits = set.fds_bits
+            let mask : UInt = 1 << bitOffset
+          #else
+            var fd_bits = set.__fds_bits
             let mask = 1 << bitOffset
+          #endif
             switch intOffset {
-            case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
-            case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
-            case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
-            case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
-            case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
-            case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
-            case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
-            case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
-            case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
-            case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
-            case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
-            case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
-            case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
-            case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
-            case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
-            case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
+            case 0: fd_bits.0 = fd_bits.0 | mask
+            case 1: fd_bits.1 = fd_bits.1 | mask
+            case 2: fd_bits.2 = fd_bits.2 | mask
+            case 3: fd_bits.3 = fd_bits.3 | mask
+            case 4: fd_bits.4 = fd_bits.4 | mask
+            case 5: fd_bits.5 = fd_bits.5 | mask
+            case 6: fd_bits.6 = fd_bits.6 | mask
+            case 7: fd_bits.7 = fd_bits.7 | mask
+            case 8: fd_bits.8 = fd_bits.8 | mask
+            case 9: fd_bits.9 = fd_bits.9 | mask
+            case 10: fd_bits.10 = fd_bits.10 | mask
+            case 11: fd_bits.11 = fd_bits.11 | mask
+            case 12: fd_bits.12 = fd_bits.12 | mask
+            case 13: fd_bits.13 = fd_bits.13 | mask
+            case 14: fd_bits.14 = fd_bits.14 | mask
+            case 15: fd_bits.15 = fd_bits.15 | mask
             default: break
             }
+          #if os(Android)
+            set.fds_bits = fd_bits
+          #else
+            set.__fds_bits = fd_bits
+          #endif
         }
 
         static func fdIsSet(fd: Int32, set: inout fd_set) -> Bool {
             let intOffset = Int(fd / SystemLibrary.nfdbits)
             let bitOffset = Int(fd % SystemLibrary.nfdbits)
+          #if os(Android)
+            let fd_bits = set.fds_bits
+            let mask = UInt(1 << bitOffset)
+          #else
+            let fd_bits = set.__fds_bits
             let mask = Int(1 << bitOffset)
+          #endif
             switch intOffset {
-            case 0: return set.__fds_bits.0 & mask != 0
-            case 1: return set.__fds_bits.1 & mask != 0
-            case 2: return set.__fds_bits.2 & mask != 0
-            case 3: return set.__fds_bits.3 & mask != 0
-            case 4: return set.__fds_bits.4 & mask != 0
-            case 5: return set.__fds_bits.5 & mask != 0
-            case 6: return set.__fds_bits.6 & mask != 0
-            case 7: return set.__fds_bits.7 & mask != 0
-            case 8: return set.__fds_bits.8 & mask != 0
-            case 9: return set.__fds_bits.9 & mask != 0
-            case 10: return set.__fds_bits.10 & mask != 0
-            case 11: return set.__fds_bits.11 & mask != 0
-            case 12: return set.__fds_bits.12 & mask != 0
-            case 13: return set.__fds_bits.13 & mask != 0
-            case 14: return set.__fds_bits.14 & mask != 0
-            case 15: return set.__fds_bits.15 & mask != 0
+            case 0: return fd_bits.0 & mask != 0
+            case 1: return fd_bits.1 & mask != 0
+            case 2: return fd_bits.2 & mask != 0
+            case 3: return fd_bits.3 & mask != 0
+            case 4: return fd_bits.4 & mask != 0
+            case 5: return fd_bits.5 & mask != 0
+            case 6: return fd_bits.6 & mask != 0
+            case 7: return fd_bits.7 & mask != 0
+            case 8: return fd_bits.8 & mask != 0
+            case 9: return fd_bits.9 & mask != 0
+            case 10: return fd_bits.10 & mask != 0
+            case 11: return fd_bits.11 & mask != 0
+            case 12: return fd_bits.12 & mask != 0
+            case 13: return fd_bits.13 & mask != 0
+            case 14: return fd_bits.14 & mask != 0
+            case 15: return fd_bits.15 & mask != 0
             default: return false
             }
         }

--- a/Sources/TCPSocket.swift
+++ b/Sources/TCPSocket.swift
@@ -27,7 +27,7 @@ public final class TCPSocket {
     /// Whether to ignore SIGPIPE signal or not
     var ignoreSigPipe: Bool {
         get {
-            #if os(Linux)
+            #if os(Linux) || os(Android)
                 return false
             #else
                 var value: Int32 = 0
@@ -41,7 +41,7 @@ public final class TCPSocket {
         }
 
         set {
-            #if os(Linux)
+            #if os(Linux) || os(Android)
                 // TODO: maybe we should call signal(SIGPIPE, SIG_IGN) here? but it affects
                 // whole process
                 return
@@ -103,7 +103,7 @@ public final class TCPSocket {
         }
         // create IPv6 socket address
         var address = sockaddr_in6()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.stride)
         #endif
         address.sin6_family = sa_family_t(AF_INET6)
@@ -151,7 +151,7 @@ public final class TCPSocket {
     func connect(host: String, port: Int) throws {
         // create IPv6 socket address
         var address = sockaddr_in6()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.stride)
         #endif
         address.sin6_family = sa_family_t(AF_INET6)

--- a/Tests/EmbassyTests/HTTPHeaderParserTests.swift
+++ b/Tests/EmbassyTests/HTTPHeaderParserTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension HTTPHeaderParserTests {
         static var allTests = [
             ("testSimpleParsing", testSimpleParsing),

--- a/Tests/EmbassyTests/HTTPServerTests.swift
+++ b/Tests/EmbassyTests/HTTPServerTests.swift
@@ -12,7 +12,8 @@ import XCTest
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
+    import FoundationNetworking
     extension HTTPServerTests {
         static var allTests = [
             ("testEnviron", testEnviron),

--- a/Tests/EmbassyTests/HeapSortTetsts.swift
+++ b/Tests/EmbassyTests/HeapSortTetsts.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension HeapSortTetsts {
         static var allTests = [
             ("testPush", testPush),

--- a/Tests/EmbassyTests/KqueueSelectorTests.swift
+++ b/Tests/EmbassyTests/KqueueSelectorTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Fang-Pen Lin. All rights reserved.
 //
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 
 import XCTest
 

--- a/Tests/EmbassyTests/MultiDictionaryTests.swift
+++ b/Tests/EmbassyTests/MultiDictionaryTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension MultiDictionaryTests {
         static var allTests = [
             ("testCaseInsenstiveMultiDictionary", testCaseInsenstiveMultiDictionary),

--- a/Tests/EmbassyTests/SelectSelectorTests.swift
+++ b/Tests/EmbassyTests/SelectSelectorTests.swift
@@ -12,7 +12,7 @@ import Dispatch
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension SelectSelectorTests {
         static var allTests = [
             ("testRegister", testRegister),

--- a/Tests/EmbassyTests/SelectorEventLoopTests.swift
+++ b/Tests/EmbassyTests/SelectorEventLoopTests.swift
@@ -12,7 +12,7 @@ import Dispatch
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension SelectorEventLoopTests {
         static var allTests = [
             ("testStop", testStop),

--- a/Tests/EmbassyTests/TCPSocketTests.swift
+++ b/Tests/EmbassyTests/TCPSocketTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension TCPSocketTests {
         static var allTests = [
             ("testAccept", testAccept),

--- a/Tests/EmbassyTests/TransportTests.swift
+++ b/Tests/EmbassyTests/TransportTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 @testable import Embassy
 
-#if os(Linux)
+#if os(Linux) || os(Android)
     extension TransportTests {
         static var allTests = [
             ("testBigChunkReadAndWrite", testBigChunkReadAndWrite),


### PR DESCRIPTION
Also gets the tests running on linux again.

I used an earlier version of this pull when packaging CookCLI for Android last weekend, termux/termux-packages#11081. I tested this pull by running `swift test` on Ubuntu 20.04 x86_64 and Android 12 AArch64 without a problem. 