### PR TITLE
Fix crashes related to breaking Swift language changes to withMemoryRebound in Xcode 14

### DIFF
--- a/Sources/TCPSocket.swift
+++ b/Sources/TCPSocket.swift
@@ -114,7 +114,7 @@ public final class TCPSocket {
         let size = socklen_t(MemoryLayout<sockaddr_in6>.size)
         // bind the address and port on socket
         guard withUnsafePointer(to: &address, { pointer in
-            return pointer.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { pointer in
+            return pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { pointer in
                 return SystemLibrary.bind(fileDescriptor, pointer, size) >= 0
             }
         }) else {
@@ -135,7 +135,7 @@ public final class TCPSocket {
         var address = sockaddr_in6()
         var size = socklen_t(MemoryLayout<sockaddr_in6>.size)
         let clientFileDescriptor = withUnsafeMutablePointer(to: &address) { pointer in
-            return pointer.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { pointer in
+            return pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { pointer in
                 return SystemLibrary.accept(fileDescriptor, pointer, &size)
             }
         }
@@ -162,7 +162,7 @@ public final class TCPSocket {
         let size = socklen_t(MemoryLayout<sockaddr_in6>.size)
         // connect to the host and port
         let connectResult = withUnsafePointer(to: &address) { pointer in
-            return pointer.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { pointer in
+            return pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { pointer in
                 return SystemLibrary.connect(fileDescriptor, pointer, size)
             }
         }
@@ -221,7 +221,7 @@ public final class TCPSocket {
         return try withUnsafeMutablePointer(to: &address) { pointer in
             let result = pointer.withMemoryRebound(
                 to: sockaddr.self,
-                capacity: Int(size)
+                capacity: 1
             ) { addressptr in
                 return function(fileDescriptor, addressptr, &size)
             }
@@ -232,7 +232,7 @@ public final class TCPSocket {
             case AF_INET:
                 return try pointer.withMemoryRebound(
                     to: sockaddr_in.self,
-                    capacity: MemoryLayout<sockaddr_in>.size
+                    capacity: 1
                 ) { addressptr in
                     return (
                         try structToAddress(
@@ -246,7 +246,7 @@ public final class TCPSocket {
             case AF_INET6:
                 return try pointer.withMemoryRebound(
                     to: sockaddr_in6.self,
-                    capacity: MemoryLayout<sockaddr_in6>.size
+                    capacity: 1
                 ) { addressptr in
                     return (
                         try structToAddress(

--- a/Tests/EmbassyTests/TestingHelpers.swift
+++ b/Tests/EmbassyTests/TestingHelpers.swift
@@ -68,7 +68,7 @@ func getUnusedTCPPort() throws -> Int {
     guard withUnsafePointer(to: &address, { pointer in
         return pointer.withMemoryRebound(
             to: sockaddr.self,
-            capacity: Int(addressSize)
+            capacity: 1
         ) { pointer in
             return bind(fileDescriptor, pointer, addressSize) >= 0
         }
@@ -81,7 +81,7 @@ func getUnusedTCPPort() throws -> Int {
     guard withUnsafeMutablePointer(to: &socketAddress, { pointer in
         return pointer.withMemoryRebound(
             to: sockaddr.self,
-            capacity: Int(socketAddressSize)
+            capacity: 1
         ) { pointer in
             return getsockname(fileDescriptor, pointer, &socketAddressSize) >= 0
         }


### PR DESCRIPTION
This PR fixes crashes presumably related to [S3-0333](https://github.com/apple/swift-evolution/blob/main/proposals/0333-with-memory-rebound.md) which adjusted the behavior of withMemoryRebound. These crashes prevent us from using this framework in Xcode 14 beta likely due to SE-0333 being accepted and included in its release. 

### Explanation
According to the docs of `withMemoryRebound` the parameter _count_ refers to "the number of instances of `Pointee` to bind to `type`." This means that it does not actually refer to the size of the rebound region, but instead to the **number** of instances of `T` being mapped within it. The previous implementation passed the size of the `MemoryLayout` rather than simply passing 1, which is the number of `socketaddr` instances we're attempting to map/bind to. 

The proposal linked previously asserted that these changes would not break source compatibility, but I have found this assumption to be flawed. Even though TCPSocket's previous implementation appeared to misunderstand the intent of the capacity parameter, it functioned nonetheless. I am willing to file an issue to the Swift team if there's anyone that can help me distill this issue down.

My fix has seemed to resolved the crashes on our end, but I would gladly appreciate others to verify my understanding. I am not too well-accustomed to C land, so it is entirely possible my understanding is flawed as well. 

In any case, if these changes can be verified and merged as soon as possible, we would be much appreciative, as we would love to continue using this library in Xcode 14 onward.

Thank you!