### PR TITLE
Avoid closing sockets twice

### DIFF
--- a/Sources/TCPSocket.swift
+++ b/Sources/TCPSocket.swift
@@ -201,8 +201,12 @@ public final class TCPSocket {
 
     /// Close the socket
     func close() {
+        guard fileDescriptor != -1 else {
+            return
+        }
         _ = SystemLibrary.shutdown(fileDescriptor, Int32(SHUT_WR))
         _ = SystemLibrary.close(fileDescriptor)
+        fileDescriptor = -1
     }
 
     func getPeerName() throws -> (String, Int) {


### PR DESCRIPTION
Either calling `shutdown` or `close` on an invalid file descriptor seems to occasionally cause a crash – this makes sure neither of those are called if the socket has already been closed.