### PR TITLE
Fix build error introduced in new v4.1.5

### DIFF
--- a/Sources/TCPSocket.swift
+++ b/Sources/TCPSocket.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Class wrapping around TCP/IPv6 socket
 public final class TCPSocket {
     /// The file descriptor number for socket
-    let fileDescriptor: Int32
+    var fileDescriptor: Int32
 
     /// Whether is this socket in block mode or not
     var blocking: Bool {


### PR DESCRIPTION
Change `fileDescriptor` in `TCPSocket` file from let to var to fix build error in version 4.1.5