### PR TITLE
fix: treat connection resets as connection closed by peer

### DIFF
--- a/Sources/Transport.swift
+++ b/Sources/Transport.swift
@@ -198,6 +198,8 @@ public final class Transport {
                 fallthrough
             case EPIPE:
                 closedByPeer()
+            case ECONNRESET:
+                closedByPeer()
 
             default:
                 fatalError("Failed to send, errno=\(number), message=\(message)")


### PR DESCRIPTION
This was the original error message I received:

Embassy/Transport.swift:203: Fatal error: Failed to send, errno=54, message=Connection reset by peer
